### PR TITLE
Update posthog-product-analytics.json

### DIFF
--- a/dashboards/posthog-product-analytics.json
+++ b/dashboards/posthog-product-analytics.json
@@ -28,8 +28,10 @@
         "events": [
           { "id": "$pageview", "math": "dau", "type": "events" }
         ],
+        "display": "ActionsLineGraph",
         "insight": "TRENDS",
-        "interval": "week"
+        "interval": "week",
+        "date_from": "-90d"
       },
       "layouts": {
         "sm": { "h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3 },

--- a/dashboards/posthog-product-analytics.json
+++ b/dashboards/posthog-product-analytics.json
@@ -26,7 +26,7 @@
       "color": "green",
       "filters": {
         "events": [
-          { "id": "$pageview", "math": "weekly_active", "type": "events" }
+          { "id": "$pageview", "math": "dau", "type": "events" }
         ],
         "insight": "TRENDS",
         "interval": "week"


### PR DESCRIPTION
Currently the WAU graph seems broken, instead we can use the group by week of the DAU to fix it.

<img width="1459" alt="Screenshot Test 2 product analytics template • Dashboards • PostHog (Google Chrome) 2023-02-02 at 17 35@2x" src="https://user-images.githubusercontent.com/22766134/216399674-5484f809-a60a-48f5-8e17-86c01e55693d.png">

Working out a way to test this now...